### PR TITLE
v0.7 deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,8 @@
+name = "SugarBLAS"
+uuid = "a4b43716-9c9d-11e8-1196-cd1a91f4cfcb"
+authors = ["Juan Antonio López Mendoza <juanlopezm94@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.5
-
-Combinatorics

--- a/src/Match/Match.jl
+++ b/src/Match/Match.jl
@@ -23,7 +23,7 @@ end
 iscommutative(op::Symbol) = _iscommutative(Val{op})
 
 _iscommutative(::Type{Val{:(+)}}) = true
-_iscommutative{T<:Val}(::Type{T}) = false
+_iscommutative(::Type{T}) where T<:Val = false
 
 """
 Output true if dictionary 'd' has a key 's' with a different value than 'v'.

--- a/src/SugarBLAS.jl
+++ b/src/SugarBLAS.jl
@@ -31,7 +31,7 @@ substracts(expr::Expr) = (expr.head == :call) & (expr.args[1] == :-)
 """
 Sugarcoat '.isnull'
 """
-isempty(nl::Nullable) = nl.isnull
+isempty(nl::Union{Missing,T}) where T = ismissing(nl)
 
 """
 Make dictionary containing the kwargs contents.
@@ -147,8 +147,8 @@ Base.copy!, Base.scale! or Base.LinAlg.axpy!.
 - `Y ±= X`
 - `Y ±= a*X`
 """
-#Must be ordered from most to least especific formulas
 macro blas!(expr::Expr)
+    #Must be ordered from most to least specific formulas
     unkeyword!(expr)
     expr = expand(expr)
     @case begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using SugarBLAS
-using Base.Test
+using Test
 
 #scale!
 @test macroexpand(SugarBLAS, :(SugarBLAS.@scale! X *= a)) == :(scale!(a, X))


### PR DESCRIPTION
I have fixed the 0.7 deprecations. I am unsure about the `isempty` method, which previously relied on the `Nullable` type, removed from Julia > 0.6. I implemented it using the new `Missing` type, and the tests go through on Julia 0.7.